### PR TITLE
Support order in Album List API

### DIFF
--- a/src/clarita/digikam/db.py
+++ b/src/clarita/digikam/db.py
@@ -5,6 +5,7 @@ import aiosqlite
 
 from ..config import IgnoredRoots, RootMap
 from ..models import File
+from ..types import AlbumOrder
 from . import albums, photos
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ class DigikamBase:
         self,
         limit: int,
         offset: int,
+        order: AlbumOrder,
         ignored_roots: IgnoredRoots,
         parent_album_id: int | None = None,
     ):
@@ -29,6 +31,7 @@ class DigikamBase:
                 db,
                 limit=limit,
                 offset=offset,
+                order=order,
                 ignored_roots=ignored_roots,
                 parent_album_id=parent_album_id,
             )

--- a/src/clarita/main.py
+++ b/src/clarita/main.py
@@ -1,6 +1,7 @@
 from datetime import datetime
+from typing import Annotated
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.requests import Request
 from fastapi.responses import FileResponse, JSONResponse, Response
@@ -39,9 +40,9 @@ digikam = DigikamSQLite(
 
 @app.get("/api/v1/albums")
 async def albums(
-    limit: int = 20,
-    offset: int = 0,
-    parent: int | None = None,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    parent: Annotated[int | None, Query(ge=0)] = None,
 ) -> models.AlbumList:
     return await digikam.albums(limit, offset, settings.ignored_roots, parent)
 
@@ -82,8 +83,8 @@ async def photo_file(photo_id: int, request: Request, response: Response):
 
 @app.get("/api/v1/photos")
 async def photos(
-    album: int | None = None,
-    limit: int = 20,
-    offset: int = 0,
+    album: Annotated[int | None, Query(ge=0)] = None,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ) -> models.PhotoList:
     return await digikam.photos(limit, offset, settings.ignored_roots, album)

--- a/src/clarita/main.py
+++ b/src/clarita/main.py
@@ -40,7 +40,7 @@ digikam = DigikamSQLite(
 
 @app.get("/api/v1/albums")
 async def albums(
-    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    limit: Annotated[int, Query(ge=1, le=100)] = 100,
     offset: Annotated[int, Query(ge=0)] = 0,
     parent: Annotated[int | None, Query(ge=0)] = None,
 ) -> models.AlbumList:
@@ -84,7 +84,7 @@ async def photo_file(photo_id: int, request: Request, response: Response):
 @app.get("/api/v1/photos")
 async def photos(
     album: Annotated[int | None, Query(ge=0)] = None,
-    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    limit: Annotated[int, Query(ge=1, le=100)] = 100,
     offset: Annotated[int, Query(ge=0)] = 0,
 ) -> models.PhotoList:
     return await digikam.photos(limit, offset, settings.ignored_roots, album)

--- a/src/clarita/main.py
+++ b/src/clarita/main.py
@@ -11,6 +11,7 @@ from .config import settings
 from .digikam.db import DigikamSQLite
 from .exceptions import DoesNotExist
 from .http import HTTP_MODIFIED_DATE_FORMAT
+from .types import AlbumOrder
 
 log.setup_logging()
 
@@ -43,8 +44,9 @@ async def albums(
     limit: Annotated[int, Query(ge=1, le=100)] = 100,
     offset: Annotated[int, Query(ge=0)] = 0,
     parent: Annotated[int | None, Query(ge=0)] = None,
+    order: Annotated[AlbumOrder, Query()] = AlbumOrder.titleAsc,
 ) -> models.AlbumList:
-    return await digikam.albums(limit, offset, settings.ignored_roots, parent)
+    return await digikam.albums(limit, offset, order, settings.ignored_roots, parent)
 
 
 @app.get("/api/v1/album/{album_id}")

--- a/src/clarita/typehint.py
+++ b/src/clarita/typehint.py
@@ -1,0 +1,6 @@
+from typing import NoReturn
+
+
+def assert_never(value: NoReturn) -> NoReturn:
+    """https://hakibenita.com/python-mypy-exhaustive-checking"""
+    assert False, f"Unhandled value: {value} ({type(value).__name__})"

--- a/src/clarita/types.py
+++ b/src/clarita/types.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class AlbumOrder(enum.Enum):
+    titleAsc = "title"
+    titleDesc = "-title"
+    dateAsc = "date"
+    dateDesc = "-date"

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-DATABASE_MAIN_PATH=tests/test-digikam4.db pytest $*
+export DATABASE_MAIN_PATH=tests/test-digikam4.db
+export DATABASE_THUMBNAIL_PATH=tests/test-thumbnails.db
+export CORS_ORIGINS='["*"]'
+pytest $*

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -12,9 +12,9 @@ def test_albums_root():
         "next": None,
         "results": [
             {"date": "2019-08-16", "id": "1", "title": ""},
-            {"date": "2019-03-03", "id": "4", "title": "Album3"},
-            {"date": "2019-02-02", "id": "3", "title": "Album2"},
             {"date": "2019-01-01", "id": "2", "title": "Album1"},
+            {"date": "2019-02-02", "id": "3", "title": "Album2"},
+            {"date": "2019-03-03", "id": "4", "title": "Album3"},
         ],
         "total": 4,
     }
@@ -26,8 +26,8 @@ def test_albums_for_parent_depth_1():
     assert response.json() == {
         "next": None,
         "results": [
-            {"date": "2019-05-05", "id": "6", "title": "Album1.2"},
             {"date": "2019-04-04", "id": "5", "title": "Album1.1"},
+            {"date": "2019-05-05", "id": "6", "title": "Album1.2"},
         ],
         "total": 2,
     }
@@ -40,4 +40,64 @@ def test_albums_for_parent_depth_2():
         "next": None,
         "results": [],
         "total": 0,
+    }
+
+
+def test_albums_order_title_asc():
+    response = client.get("/api/v1/albums?order=title")
+    assert response.status_code == 200
+    assert response.json() == {
+        "next": None,
+        "results": [
+            {"date": "2019-08-16", "id": "1", "title": ""},
+            {"date": "2019-01-01", "id": "2", "title": "Album1"},
+            {"date": "2019-02-02", "id": "3", "title": "Album2"},
+            {"date": "2019-03-03", "id": "4", "title": "Album3"},
+        ],
+        "total": 4,
+    }
+
+
+def test_albums_order_title_desc():
+    response = client.get("/api/v1/albums?order=-title")
+    assert response.status_code == 200
+    assert response.json() == {
+        "next": None,
+        "results": [
+            {"date": "2019-03-03", "id": "4", "title": "Album3"},
+            {"date": "2019-02-02", "id": "3", "title": "Album2"},
+            {"date": "2019-01-01", "id": "2", "title": "Album1"},
+            {"date": "2019-08-16", "id": "1", "title": ""},
+        ],
+        "total": 4,
+    }
+
+
+def test_albums_order_date_asc():
+    response = client.get("/api/v1/albums?order=date")
+    assert response.status_code == 200
+    assert response.json() == {
+        "next": None,
+        "results": [
+            {"date": "2019-01-01", "id": "2", "title": "Album1"},
+            {"date": "2019-02-02", "id": "3", "title": "Album2"},
+            {"date": "2019-03-03", "id": "4", "title": "Album3"},
+            {"date": "2019-08-16", "id": "1", "title": ""},
+        ],
+        "total": 4,
+    }
+
+
+def test_albums_order_date_desc():
+    response = client.get("/api/v1/albums?order=-date")
+    assert response.status_code == 200
+    assert response.json() == {
+        "next": None,
+        "results": [
+            {"date": "2019-08-16", "id": "1", "title": ""},
+            {"date": "2019-03-03", "id": "4", "title": "Album3"},
+            {"date": "2019-02-02", "id": "3", "title": "Album2"},
+            {"date": "2019-01-01", "id": "2", "title": "Album1"},
+        ],
+        "total": 4,
     }

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -9,7 +9,7 @@ def test_photos_no_album():
     response = client.get("/api/v1/photos")
     assert response.status_code == 200
     assert response.json() == {
-        "next": 20,
+        "next": None,
         "results": [
             {
                 "date_and_time": "2019-08-16T17:12:00",
@@ -130,6 +130,30 @@ def test_photos_no_album():
                 "filename": "image20.jpg",
                 "id": "20",
                 "title": "image20.jpg",
+            },
+            {
+                "date_and_time": "2014-03-23T10:12:19",
+                "filename": "image19.jpg",
+                "id": "19",
+                "title": "image19.jpg",
+            },
+            {
+                "date_and_time": "2014-03-15T09:41:35",
+                "filename": "image2.jpg",
+                "id": "2",
+                "title": "Title of image2",
+            },
+            {
+                "date_and_time": "2012-12-31T11:26:00",
+                "filename": "image22.jpg",
+                "id": "22",
+                "title": "image22.jpg",
+            },
+            {
+                "date_and_time": "2012-03-03T16:21:17",
+                "filename": "image21.jpg",
+                "id": "21",
+                "title": "image21.jpg",
             },
         ],
         "total": 24,


### PR DESCRIPTION
- Title (A->Z) (`?order=title`)
- Title (Z->A) (`?order=-title`)
- Date (Old->New) (`?order=date`)
- Date (New->Old) (`?order=-date`)

Default to order by title.

Fixes #4.